### PR TITLE
Support building against Qt5

### DIFF
--- a/bdbvu.pro
+++ b/bdbvu.pro
@@ -25,6 +25,7 @@ HEADERS += mainwindow.h \
     database.h
 FORMS += mainwindow.ui
 DEFINES += HAVE_CXX_STDHEADERS
+QT += widgets
 
 # environment specific settings (OS X)
 osx {

--- a/database.cpp
+++ b/database.cpp
@@ -105,7 +105,7 @@ void database::opensubdb(const QString &dbname)
     closesubdb();
     try {
         sdb = new Db(&env, 0);
-        sdb->open(0, filename.toAscii(), dbname.toAscii(), DB_UNKNOWN, DB_RDONLY | DB_RDWRMASTER, 0);
+        sdb->open(0, filename.toLatin1(), dbname.toLatin1(), DB_UNKNOWN, DB_RDONLY | DB_RDWRMASTER, 0);
         buildKeyList();
     } catch (DbException ex) {
         closesubdb();
@@ -132,7 +132,7 @@ static QString makeVisible(const QString& s) {
     QString r;
     foreach (QChar c, s) {
         if (c != QChar('\n') && (c < QChar(' ') || c > QChar('~')))
-            r.append(QString("\\%1").arg(c.toAscii() & 0xff, 2, 16, QChar('0')));
+            r.append(QString("\\%1").arg(c.toLatin1() & 0xff, 2, 16, QChar('0')));
         else if (c == QChar('\\'))
             r.append("\\\\");
         else

--- a/database.h
+++ b/database.h
@@ -35,7 +35,7 @@ public:
     dbexception(const QString& message) : std::exception() { this->message = message; }
     virtual ~dbexception() throw() {}
 
-    const char* what() const throw() { return message.toAscii(); }
+    const char* what() const throw() { return message.toLatin1(); }
 
 private:
     QString message;

--- a/main.cpp
+++ b/main.cpp
@@ -18,7 +18,7 @@
 
 */
 
-#include <QtGui/QApplication>
+#include <QApplication>
 #include "mainwindow.h"
 
 int main(int argc, char *argv[])

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -68,7 +68,7 @@ void MainWindow::openFile(QString filename)
 {
     db.close();
     try {
-        db.open(filename.toAscii());
+        db.open(filename.toLatin1());
     }
     catch (dbexception ex) {
         QMessageBox::critical(this, "BDBVu", ex.what());


### PR DESCRIPTION
Qt4 has been deprecated since Qt5's first release on December 19th 2012. Make the code compile with Qt5.

`QString::toAscii()` was obsoleted. The function `QString::toLatin1()` does the same.